### PR TITLE
soong: Conditionally spoof ro.product.first_api_level to 32 [1/2]

### DIFF
--- a/build/soong/Android.bp
+++ b/build/soong/Android.bp
@@ -636,3 +636,20 @@ uses_miui_camera {
         },
     },
 }
+
+soong_config_module_type {
+    name: "spoof_first_api_level_32",
+    module_type: "cc_defaults",
+    config_namespace: "lineageGlobalVars",
+    bool_variables: ["spoof_first_api_level_32"],
+    properties: ["cppflags"]
+}
+
+spoof_first_api_level_32 {
+    name: "spoof_first_api_level_32_defaults",
+    soong_config_variables: {
+        spoof_first_api_level_32: {
+            cppflags: ["-DSPOOF_FIRST_API_LEVEL_32"],
+        },
+    },
+}

--- a/config/BoardConfigSoong.mk
+++ b/config/BoardConfigSoong.mk
@@ -61,7 +61,8 @@ SOONG_CONFIG_lineageGlobalVars += \
     uses_nothing_camera \
     uses_oplus_camera \
     include_miui_camera \
-    uses_oppo_camera
+    uses_oppo_camera \
+    spoof_first_api_level_32
 
 SOONG_CONFIG_NAMESPACES += lineageNvidiaVars
 SOONG_CONFIG_lineageNvidiaVars += \
@@ -144,6 +145,8 @@ SOONG_CONFIG_lineageGlobalVars_target_surfaceflinger_udfps_lib := $(TARGET_SURFA
 SOONG_CONFIG_lineageGlobalVars_target_trust_usb_control_path := $(TARGET_TRUST_USB_CONTROL_PATH)
 SOONG_CONFIG_lineageGlobalVars_target_trust_usb_control_enable := $(TARGET_TRUST_USB_CONTROL_ENABLE)
 SOONG_CONFIG_lineageGlobalVars_target_trust_usb_control_disable := $(TARGET_TRUST_USB_CONTROL_DISABLE)
+SOONG_CONFIG_lineageGlobalVars_spoof_first_api_level_32 := $(SPOOF_FIRST_API_LEVEL_32)
+
 ifneq ($(filter $(QSSI_SUPPORTED_PLATFORMS),$(TARGET_BOARD_PLATFORM)),)
 SOONG_CONFIG_lineageQcomVars_qcom_display_headers_namespace := vendor/qcom/opensource/commonsys-intf/display
 else


### PR DESCRIPTION
Devices that shipped on API 33 or higher need to set ro.product.first_api_level to 32 in order to pass integrity.

Set SPOOF_FIRST_API_LEVEL_32 := true in BoardConfig*.mk to enable.

Change-Id: I4478f228c0ee4e442100df2d99563be8ca41b9e0